### PR TITLE
Implement commitkeys customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ chip.values
 // -> ['parameters', 'array', 'nested', 'items', 'spread']
 ```
 
+### Change the commit keys
+Note that keys can be specified either by key or by keycode, for example `';'` is equivalent to `'Semicolon'`, and either `'b'` or `'KeyB'` works. However, since lists can be specified `' '` must be provided as `'Space'`.
+```html
+<!-- With the attribute ->
+<simple-chip commitkeycode="Space">
+```
+or 
+```js
+// With the property
+chip.commitKeycode = 'Insert';
+
+// Both versions also take comma delimited lists
+chip.commitKeycode = 'Enter, Tab, Space';
+```
+
 ## Viewing the Element
 
 ```

--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
     "mocha": "^5.2.0",
     "wct-mocha": "^1.0.0"
   },
-  "version": "1.1.4",
+  "version": "1.2.0",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "start": "polymer serve",
     "test": "polymer test"
   },
   "repository": {

--- a/simple-chip.js
+++ b/simple-chip.js
@@ -14,6 +14,16 @@ function flattenDeep(arr1) {
  * @demo demo/index.html
  */
 class SimpleChip extends LitElement {
+
+  static get properties() { return {
+    commitKeycode: {type: String}
+  }}
+
+  constructor() {
+    super();
+    this.commitKeycode = "Enter";
+  }
+
   render() {
     return html`
       <style>
@@ -139,9 +149,11 @@ class SimpleChip extends LitElement {
   }
 
   __keydown(e) {
-    if (e.key === "Enter") {
+    const commitCodes = this.commitKeycode.split(',').map(k => k.trim());
+    
+    if (commitCodes.includes(e.key) || commitCodes.includes(e.code)) {
       this.__change();
-    } else if (e.key === "Backspace") {
+    } else if (e.code === "Backspace") {
       if (this.input.value.length === 0) {
         this.removeLast();
       }


### PR DESCRIPTION
Now can specify keys or keycodes to create chips on. Use the attribute `<simple-chip commitkeycode="Key">` or the property `chip.commitKeycode = "KeyA, KeyB";`